### PR TITLE
Better concat of multiple PropertyName-PropertyValue pairs

### DIFF
--- a/Public/Update-LogicMonitorCollectorProperties-Function.ps1
+++ b/Public/Update-LogicMonitorCollectorProperties-Function.ps1
@@ -76,7 +76,7 @@ Function Update-LogicMonitorCollectorProperties {
 
     # Initialize variables.
     [int]$index = 0
-    [string]$propertyData = ""
+    $propertyData = @{}
     [string]$standardProperties = ""
     [string]$data = ""
     [string]$httpVerb = 'PUT'
@@ -107,13 +107,13 @@ Function Update-LogicMonitorCollectorProperties {
     If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $EventLogSource -EntryType Information -Message $message -EventId 5417}
 
     Foreach ($property in $PropertyNames) {
-        $propertyData += "{`"$property`":`"$($PropertyValues[$index])`"}"
+        $propertyData.add($property, $PropertyValues[$index])
 
         $index++
     }
 
     # I am assigning $propertyData to $data, so that I can use the same $requestVars concatination and Invoke-RestMethod as other cmdlets in the module.
-    $data = $propertyData
+    $data = $propertyData | ConvertTo-Json -Depth 6
 
     $message = ("{0}: Finished updating `$data. The value update is {1}." -f (Get-Date -Format s), $data)
     If (($BlockLogging) -AND ($PSBoundParameters['Verbose'])) {Write-Verbose $message} ElseIf ($PSBoundParameters['Verbose']) {Write-Verbose $message; Write-EventLog -LogName Application -Source $EventLogSource -EntryType Information -Message $message -EventId 5417}


### PR DESCRIPTION
Changes `$propertyData` to a hashtable to take advantage of `.add(propertyName,propertyValue)` method. Current implementation created malformed json-formatted strings. 

 ```
> [string[]]$propNames = 'description','collectorGroupId'
> [string[]]$propValues = 'collector_description',5
> foreach ($property in $propNames) { $propertyData += "{`"$property`":`"$($PropValues[$index])`"}";    $index++}
> $propertyData
{"":""}{"description":"collector_description"}{"collectorGroupId":"5"}
```